### PR TITLE
Fix serial console command in Type2 docs

### DIFF
--- a/docs/Hacking/Type2.md
+++ b/docs/Hacking/Type2.md
@@ -31,7 +31,7 @@ Fire up your SSH client and connect with user `root` to the Gateway IP on defaul
 As first step into your brand-new rooted Gateway, it is a good idea to always ensure the serial console port is enabled - this is a very useful feature in case of disasters, so just do it. Execute the following command:
 
 ```bash
-sed -i -e 's/#//' -e 's#askconsole:.*\$#askconsole:/bin/ash#' /etc/inittab
+sed -i -e 's/#//' -e 's#askconsole:.*$#askconsole:/bin/ash#' /etc/inittab
 ```
 
 At this point you have a rooted `Type 2` image on your Gateway, but your trip is not over. Take note of the exact `Type 2` firmware version you are now running, it could be useful to remember in future for recovery purposes.


### PR DESCRIPTION
The serial console command to update inittab should not escape the dollar sign for end of line.