### PR TITLE
Add code NKL for UK ISPs

### DIFF
--- a/docs/Repository.md
+++ b/docs/Repository.md
@@ -18,6 +18,8 @@ Other branding codes you could see worldwide:
 | TIS  | Tiscali      | Italy             |
 | TI   | TIM          | Italy             |
 | TN   | Telenor      | Sweden            |
+| TN   | Telenor      | Sweden            |
+| NKL  | Giganet, UW) | UK                |
 
 Type 1/2/3 indicates if it can be rooted directly. For Type 2 only, Root Strategy # indicates how to do it. Please, **don't miss these important details** whenever you add a new firmware version to this page if you know about that.
 


### PR DESCRIPTION
Add code `NKL` for UK small ISPs for the following; However im not sure is is just a UK generic one but saying that https://github.com/hack-technicolor/hack-technicolor/pull/370) is also used for ISP Vodafone UK.

DGA0122NLK for UK ISP UW, Also uses SSID TNCAPXXXXX
<img width="654" height="561" alt="DGA0122NLK" src="https://github.com/user-attachments/assets/57520e43-a720-4585-8078-1ab2b5879965" />

DGA04315NLK for UK ISP Giganet, Also uses SSID Giganet XXXX
<img width="1320" height="1710" alt="photo_2026-08-28_18-02-16 (2)" src="https://github.com/user-attachments/assets/005ee1ba-9271-4bc5-8522-321a8c12e6d5" />
